### PR TITLE
Potential fix for code scanning alert no. 8: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build-on-master.yml
+++ b/.github/workflows/build-on-master.yml
@@ -7,6 +7,8 @@ on:
     branches: [ master ]
   pull_request:
     branches-ignore: [ dependabot/** ]
+permissions:
+  contents: read
 jobs:
   build:
     # The type of runner that the job will run on


### PR DESCRIPTION
Potential fix for [https://github.com/vzwingma/gestion-budget-ihm/security/code-scanning/8](https://github.com/vzwingma/gestion-budget-ihm/security/code-scanning/8)

To fix the issue, we will add a `permissions` block to the root of the workflow file. This block will define the minimal permissions required for the workflow. Since the workflow does not appear to require write permissions for the `GITHUB_TOKEN`, we will set `contents: read` as the default permission. This ensures that the workflow has only read access to the repository contents unless explicitly overridden in individual jobs.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
