### PR TITLE
Potential fix for code scanning alert no. 7: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build-on-master.yml
+++ b/.github/workflows/build-on-master.yml
@@ -7,6 +7,8 @@ on:
     branches: [ master ]
   pull_request:
     branches-ignore: [ dependabot/** ]
+permissions:
+  contents: read
 jobs:
   build:
     # The type of runner that the job will run on
@@ -63,6 +65,9 @@ jobs:
   sonarcloud:
     runs-on: ubuntu-latest
     needs: lint
+    permissions:
+      contents: read
+      security-events: read
     steps:
       - uses: actions/checkout@v4
         with:
@@ -82,6 +87,9 @@ jobs:
   # Deploy sur S3
   deploy:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      actions: write
     env:
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}


### PR DESCRIPTION
Potential fix for [https://github.com/vzwingma/gestion-budget-ihm/security/code-scanning/7](https://github.com/vzwingma/gestion-budget-ihm/security/code-scanning/7)

To fix the issue, add a `permissions` block to the root of the workflow file to define the least privileges required for all jobs. Additionally, override permissions for specific jobs if they require additional access. For this workflow:
- The `contents: read` permission is sufficient for most jobs.
- The `sonarcloud` job requires `contents: read` and possibly `security-events: read` for SonarCloud scanning.
- The `deploy` job may require `contents: read` and `actions: write` for deployment.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
