### PR TITLE
Potential fix for code scanning alert no. 6: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build-on-tags.yml
+++ b/.github/workflows/build-on-tags.yml
@@ -1,5 +1,10 @@
 name: CI/CD - Release IHM
 
+permissions:
+  contents: read
+  secrets: read
+  actions: write
+
 # Controls when the action will run.
 on:
   # Triggers the workflow on push or pull request events but only for tags


### PR DESCRIPTION
Potential fix for [https://github.com/vzwingma/gestion-budget-ihm/security/code-scanning/6](https://github.com/vzwingma/gestion-budget-ihm/security/code-scanning/6)

To fix the issue, we will add a `permissions` block to the workflow. This block will explicitly define the minimal permissions required for the workflow to function correctly. Based on the workflow's steps, the following permissions are needed:
- `contents: read` for accessing the repository's contents.
- `secrets: read` for accessing secrets like `OIDC_CLIENT_ID`, `OIDC_CLIENT_SECRET`, and `API_GW_API_KEY`.
- `actions: write` for uploading and downloading artifacts.

The `permissions` block will be added at the root level of the workflow to apply to all jobs. If specific jobs require different permissions, we can override the root-level permissions by adding a `permissions` block to those jobs.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
