### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build-on-all.yml
+++ b/.github/workflows/build-on-all.yml
@@ -6,6 +6,9 @@ on:
     # Sequence of patterns matched against refs/heads
     branches-ignore: [ master ]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     # The type of runner that the job will run on


### PR DESCRIPTION
Potential fix for [https://github.com/vzwingma/gestion-budget-ihm/security/code-scanning/2](https://github.com/vzwingma/gestion-budget-ihm/security/code-scanning/2)

To fix the issue, we will add a `permissions` block to the root of the workflow file. This block will define the minimum required permissions for the workflow. Based on the actions performed in the workflow, the `contents: read` permission is sufficient, as the workflow only reads repository contents and does not perform any write operations.

The `permissions` block will be added at the top level of the workflow file, ensuring that it applies to all jobs in the workflow.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
