### PR TITLE
fix(ci): use # as sed delimiter in .env.production substitution

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+* text=auto eol=lf
+
+*.yml text eol=lf
+*.yaml text eol=lf
+*.sh text eol=lf

--- a/.github/workflows/build-on-tags.yml
+++ b/.github/workflows/build-on-tags.yml
@@ -64,11 +64,11 @@ jobs:
           CONFIG_URL_BACKENDS: ${{ vars.CONFIG_URL_BACKENDS }}
           API_GW_API_KEY: ${{ secrets.API_GW_API_KEY }}
         run: |
-          sed -i 's/__BUDGET_IHM_VERSION__/${{ steps.get_version.outputs.VERSION }}/g' external-ressources/conf/.env.production;
-          sed -i 's/__OIDC_CLIENT_ID__/${{ secrets.OIDC_CLIENT_ID }}/g' external-ressources/conf/.env.production;
-          sed -i 's/__OIDC_CLIENT_SECRET__/${{ secrets.OIDC_CLIENT_SECRET }}/g' external-ressources/conf/.env.production;
-          sed -i 's/__CONFIG_URL_BACKENDS__/${{ vars.CONFIG_URL_BACKENDS }}/g' external-ressources/conf/.env.production;
-          sed -i 's/__API_GW_API_KEY__/${{ secrets.API_GW_API_KEY }}/g' external-ressources/conf/.env.production;
+          sed -i 's#__BUDGET_IHM_VERSION__#${{ steps.get_version.outputs.VERSION }}#g' external-ressources/conf/.env.production;
+          sed -i 's#__OIDC_CLIENT_ID__#${{ secrets.OIDC_CLIENT_ID }}#g' external-ressources/conf/.env.production;
+          sed -i 's#__OIDC_CLIENT_SECRET__#${{ secrets.OIDC_CLIENT_SECRET }}#g' external-ressources/conf/.env.production;
+          sed -i 's#__CONFIG_URL_BACKENDS__#${{ vars.CONFIG_URL_BACKENDS }}#g' external-ressources/conf/.env.production;
+          sed -i 's#__API_GW_API_KEY__#${{ secrets.API_GW_API_KEY }}#g' external-ressources/conf/.env.production;
       - run: mv external-ressources/conf/.env.production .env
         name: Set env PRODUCTION
       - run: npm run build --if-present


### PR DESCRIPTION
CONFIG_URL_BACKENDS is a URL containing '/', which collided with the sed delimiter and broke the expression (unknown option to `s'). Also adds .gitattributes to force LF on yml/sh files.